### PR TITLE
Summarize both error and warning log messages

### DIFF
--- a/cmd/show.go
+++ b/cmd/show.go
@@ -407,7 +407,7 @@ func analyzeLogs(logsURLs []*url.URL) {
 						}
 					}
 				}
-				r = regexp.MustCompile(` level=error.*`)
+				r = regexp.MustCompile(` level=(error|warn).*`)
 				matches = r.FindAllStringSubmatch(string(body), 10000)
 				for _, match := range matches {
 					for _, errorMessage := range match {


### PR DESCRIPTION
Both error and warning logs cause the check-log-errors check to fail. Hence, let's display the count of all the ones that are encountered, instead of focusing on errors only.